### PR TITLE
Added the ability to create the workspace in any desired directory for setup-rox-simulation.sh 

### DIFF
--- a/package-setup/setup-rox-simulation.sh
+++ b/package-setup/setup-rox-simulation.sh
@@ -6,13 +6,15 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 YELLOW='\033[0;33m'
 WHITE='\033[0;37m'
+NC='\033[0m'
 
-echo "Welcome to the support assistant for setting up the ROX Simulation packages"
-echo "The workspace will be created in the /home/USER/ folder. In the future, we will add the option, to create the workspace in any desired directory"
+echo -e "${GREEN}==========================================================================="
+echo -e "Welcome to the support assistant for setting up the ROX Simulation packages"
+echo -e "===========================================================================${NC}"
 
 # Check if ROS is sourced
 empty_ros_distro=true
-ros_distros=" "
+
 if [ "$ROS_DISTRO" == "" ]; then
 	echo "ROS Distro is not sourced."
     for dir in /opt/ros/*/; do
@@ -20,69 +22,86 @@ if [ "$ROS_DISTRO" == "" ]; then
             empty_ros_distro=false
             echo -e "$GREEN"
             echo "  " $(basename "$dir")
+            echo -e "$NC"
         fi
     done
 
     if [ $empty_ros_distro == true ]; then
         echo "ROS 2 is not installed at all"
         echo "Please continue the installation once ROS 2 is installed"
-        echo "Abort"
+        echo -e "${RED}Abort"
     else
-        echo -e "${RED} Please source any one of the ROS Distros above and try again later"
-        echo -e "${RED} Example: source /opt/ros/YOUR_DISTRO/setup.bash"
-        echo "Abort"
+        echo -e "${RED}Please source any one of the ROS Distros above and try again later${NC}"
+        echo -e "${RED}Example: source /opt/ros/YOUR_DISTRO/setup.bash${NC}"
+        echo -e "${RED}Abort"
         exit 0
     fi
 fi
 
-# Check if the client ws is already there in the home folder
-cd ~/
-is_ws_installed=""
+# Get custom workspace base directory
+workspace_base=$(bash utils/get_absolute_path.sh)
+if [ -z "$workspace_base" ]; then
+    echo -e "${RED}Failed to get a valid workspace directory${NC}"
+    echo -e "${RED}Abort"
+    exit 0
+fi
+# Create workspace path using this base
+directory_root="${workspace_base}/${ROS_DISTRO}_ws"
+directory="${directory_root}/src"
 
-if [ -d "${ROS_DISTRO}_ws" ]; then
-    echo "${ROS_DISTRO}_ws already exists."
+if [ -d "${directory_root}" ]; then
+    echo "${directory_root} already exists."
     echo -n "Do you want to delete it before continuing? (Y/n)"
     read is_ws_installed
 
     if [[ "$is_ws_installed" == "y" || "$is_ws_installed" == "Y" ]]; then
-        echo -e "  Deleting.."
-        rm -rf ${ROS_DISTRO}_ws
-        echo -e "  ${ROS_DISTRO}_ws has been deleted"
+        echo -e " Checking permissions..."
+
+        # Check if we have permission to delete
+        parent_dir=$(dirname "${directory_root}")
+        if [ ! -w "${parent_dir}" ]; then
+            echo -e "${YELLOW}You don't have permission to delete this directory.${NC}"
+            echo -n "Continue with sudo? (Y/n)"
+            read use_sudo
+
+            if [[ "$use_sudo" == "y" || "$use_sudo" == "Y" ]]; then
+                echo -e "Deleting ${directory_root}..."
+                sudo rm -rf "${directory_root}"
+            else
+                echo -e "${RED}Abort"
+                exit 0
+            fi
+        else
+            echo -e "Deleting ${directory_root}..."
+            rm -rf "${directory_root}"
+        fi
+
+        echo -e "${GREEN}${directory_root} has been deleted${NC}"
     else
-        echo "Abort"
+        echo -e "${RED}Abort"
         exit 0
     fi
 fi
 
-uni_ans=""
-robot_model=""
-
-# Go to home directory
-cd ~
-
-skip_depend="phidgets_drivers ur_client_library ur_msgs ur_robot_driver"
+skip_depend="phidgets_drivers ur_client_library ur_msgs neo_relayboard_v3"
 
 # Install build tool
-echo "Installing colcon extensions"
+echo "Installing colcon extensions..."
 sudo apt install python3-colcon-common-extensions
 
 # Installing CycloneDDS
-echo "Installing CycloneDDS"
+echo "Installing CycloneDDS..."
 sudo apt install ros-$ROS_DISTRO-rmw-cyclonedds-cpp
 
 #Install xterm
 
 sudo apt install xterm
 
-cd ~
-
-directory="${ROS_DISTRO}_ws/src"
-directory_root="${ROS_DISTRO}_ws"
-
 mkdir -p "$directory"
 cd "$directory"
 
 # clone git repos here...
+echo "Cloning the necessary repositories..."
 git clone --branch $ROS_DISTRO     https://github.com/neobotix/rox.git
 git clone --branch $ROS_DISTRO     https://github.com/neobotix/neo_local_planner2.git
 git clone --branch $ROS_DISTRO     https://github.com/neobotix/neo_localization2.git
@@ -94,17 +113,25 @@ git clone --branch main            https://github.com/neobotix/neo_gz_worlds.git
 
 cd ..
 
-echo "skipping to install following dependencies:" $skip_depend
+echo -e "${YELLOW}Skipping to install following dependencies:${NC}" $skip_depend
 # Install relevant dependencies
 rosdep install --from-paths ./src --ignore-src --rosdistro $ROS_DISTRO -r --skip-keys "$skip_depend"
 
 # build workspace
+echo "Building the workspace..."
 colcon build --symlink-install 
 
+echo -e "The following changes will be made to your ~/.bashrc file:"
+echo "  1. Setting LC_NUMERIC=en_US.UTF-8"
+echo "  2. Auto-sourcing this workspace on terminal startup"
+# Set UTF-8 settings to US
 echo "export LC_NUMERIC="en_US.UTF-8" " >> ~/.bashrc
 
-echo "source ~/"$directory_root"/install/setup.bash" >> ~/.bashrc
+# can add option here
+echo "source $directory_root/install/setup.bash" >> ~/.bashrc
 
-echo "Installation successful !!!"
+echo -e "${YELLOW}Note:${NC} If you have multiple ROS workspaces, auto-sourcing might cause conflicts."
 
+echo -e "${GREEN}Installation successful !!!${NC}"
+echo -e "Workspace '${GREEN}${ROS_DISTRO}_ws${NC}' installed at ${GREEN}${workspace_base}${NC}"
 exit 0

--- a/package-setup/utils/get_absolute_path.sh
+++ b/package-setup/utils/get_absolute_path.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# This script reads a path from the user, validates it, and returns the absolute path
+# Returns the absolute path on stdout
+# All other diagnostic messages go to stderr
+
+# exit if any command below fails
+set -e
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+# Message handling functions
+msg() { echo "$@" >&2; }
+info() { echo -e "${GREEN}$@${NC}" >&2; }
+warn() { echo -e "${YELLOW}$@${NC}" >&2; }
+error() { echo -e "${RED}$@${NC}" >&2; }
+prompt() { echo -n "$@ " >&2; }
+
+# Get absolute path
+get_abs_path() {
+  # $1 : directory path
+  echo "$(cd "$1" 2>/dev/null && pwd || echo "")"
+}
+
+# Function to handle operations requiring sudo
+# Parameters:
+#   $1: Directory to check for write permissions
+#   $2: Command to run
+#   $3: Success message
+#   $4: Error message if sudo denied
+run_with_sudo() {
+    local check_dir="$1"
+    local command="$2"
+    local success_msg="$3"
+    local error_msg="$4"
+    
+    if [ ! -w "$check_dir" ]; then
+        warn "Warning: You don't have write permission to $check_dir"
+        msg "This operation requires root privileges"
+        prompt "Continue with sudo? (Y/n):"
+        read use_sudo
+        
+        if [[ "$use_sudo" == "y" || "$use_sudo" == "Y" ]]; then
+            if sudo bash -c "$command"; then
+                info "$success_msg"
+            else
+                error "Command failed with sudo"
+                msg "Abort"
+                exit 0
+            fi
+        else
+            error "Unable to get path, $error_msg"
+            msg "Abort"
+            exit 0
+        fi
+    else
+        bash -c "$command"
+        info "$success_msg"
+    fi
+}
+
+# Prompt for parent directory
+prompt "Enter the workspace directory path (leave empty for default $HOME/):"
+read parent_dir
+
+# Set to home directory if empty
+if [ -z "$parent_dir" ]; then
+    msg "Setting workspace directory path to $HOME/"
+    parent_dir=~
+else
+    # Check if the path is relative
+    if [[ ! "$parent_dir" = /* ]]; then
+        msg "Using relative path from home directory"
+        parent_dir="$HOME/$parent_dir"
+    fi
+    # Check if the parent directory exists
+    if [ ! -d "$parent_dir" ]; then
+        prompt "Parent directory $parent_dir doesn't exist. Create it? (Y/n):"
+        read create_parent
+        if [[ "$create_parent" == "y" || "$create_parent" == "Y" ]]; then
+            # Check if we need root privileges to create the parent
+            parent_of_dir=$(dirname "$parent_dir")
+            
+            # Create directory and make it writable by current user if needed
+            run_with_sudo "$parent_of_dir" \
+                "mkdir -p \"$parent_dir\" && chown $USER:$(id -gn) \"$parent_dir\"" \
+                "Parent directory created successfully and permissions set" \
+                "cannot create directory"
+        else
+            msg "Parent directory not created"
+            msg "Abort"
+            exit 0
+        fi
+    elif [ ! -w "$parent_dir" ]; then
+        # Parent exists but isn't writable
+        run_with_sudo "$parent_dir" \
+            "chmod u+w \"$parent_dir\"" \
+            "Directory permissions updated successfully" \
+            "cannot modify permissions"
+    fi
+fi
+
+# Get absolute path after ensuring directory exists
+parent_dir=$(get_abs_path "$parent_dir")
+if [ -z "$parent_dir" ]; then
+    error "Failed to get absolute path"
+    exit 0
+fi
+
+# Only output the path to stdout for capture
+echo "$parent_dir"
+exit 0


### PR DESCRIPTION
#68 
1. Added the ability to create the workspace in any desired directory for simulation setup files to [setup-rox-simulation.sh](http://setup-rox-simulation.sh/). Also handled general edge cases and seeking appropriate write permissions.
2. removed unused variables, improved formatting and added info messages
3. added a reusable utils get_absolute_path.sh file to get a custom path and create the respective directories
4. removed ur_robot_driver and added neo_relayboard_v3 to skip dependencies to [setup-rox-simulation.sh](http://setup-rox-simulation.sh/)

![image](https://github.com/user-attachments/assets/7f08c2af-f607-4232-8f21-50099a0cdde7)
![image](https://github.com/user-attachments/assets/17183ed0-03f0-493b-b2da-ba2f4d40b845)
![image](https://github.com/user-attachments/assets/07c1136e-0ed1-44c2-a944-9b3b4029076a)
