### PR TITLE
Release Action

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -2,6 +2,9 @@ name: Build Debian package
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,8 +1,6 @@
 name: Build Debian package
 
-on:
-  push
-  pull_request
+on: [ push, pull_request ]
 
 jobs:
   build:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,18 +1,8 @@
-name: Build debian package
+name: Build Debian package
 
 on:
-  push:
-    branches:
-      - noble
-#     tags:
-#       - v.*
-  pull_request:
-    branches:
-      - noble
-#     tags:
-#       - v.*
-  schedule: #trigger for every friday at 5:30 UTC
-    - cron: '30 5 * * 5'
+  push
+  pull_request
 
 jobs:
   build:
@@ -20,16 +10,25 @@ jobs:
   
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: 'Install Dependencies'
         run: sudo apt install -y dpkg-dev
 
       - name: 'Build Debian Package'
         run: cd debian && ./make_deb.sh
-          
+
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v4
         with:
           name: neobotix-tools.deb
           path: debian/neobotix-tools.deb
+
+      - name: Release
+        uses: softprops/action-gh-release@v3
+        if: github.ref_type == 'tag'
+        with:
+          files: |
+            debian/neobotix-tools.deb
+
+

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -17,7 +17,7 @@ jobs:
         run: cd debian && ./make_deb.sh
 
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: neobotix-tools.deb
           path: debian/neobotix-tools.deb


### PR DESCRIPTION
Changes the workflow file such that a push with a tag automatically creates a release. The Debian package is attached as a download which makes it permanently accessible. This eliminates the need for temporary build artifacts that have to be regenerated regularly and are not freely accessible (they are still created though, for debugging purposes, even on normal pushes).

See here for an example: https://github.com/neojaw/robot-setup-tool/releases/tag/v23.42.2

@padhupradheep does this make sense for us?